### PR TITLE
Add template marketplace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,5 @@ STORAGE_SKIP_BUCKET_CHECK=false
 # OPENID_SCOPE=openid profile email
 # OPENID_TOKEN_URL=
 # OPENID_USER_INFO_URL=
+# Template Plugins
+TEMPLATE_PLUGIN_DIR=plugins/templates

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Start creating your standout resume with Reactive Resume today!
 - Jot down personal notes specific to your resume that's only visible to you
 - Lock a resume to prevent making any further edits (useful for master templates)
 - **Dozens of templates** to choose from, ranging from professional to modern
+- Browse community-made templates from the new marketplace and share your own
 - Design your resume using the standardised EuroPass design template
 - Supports printing resumes in A4 or Letter page formats
 - Design your resume with any font that's available on [Google Fonts](https://fonts.google.com/)

--- a/apps/client/src/constants/query-keys.ts
+++ b/apps/client/src/constants/query-keys.ts
@@ -8,3 +8,4 @@ export const LANGUAGES_KEY: QueryKey = ["translation", "languages"];
 export const RESUME_KEY: QueryKey = ["resume"];
 export const RESUMES_KEY: QueryKey = ["resumes"];
 export const RESUME_PREVIEW_KEY: QueryKey = ["resume", "preview"];
+export const TEMPLATES_KEY: QueryKey = ["templates"];

--- a/apps/client/src/pages/builder/sidebars/right/sections/template.tsx
+++ b/apps/client/src/pages/builder/sidebars/right/sections/template.tsx
@@ -1,8 +1,9 @@
 import { t } from "@lingui/macro";
 import { AspectRatio } from "@reactive-resume/ui";
-import { cn, templatesList } from "@reactive-resume/utils";
+import { cn } from "@reactive-resume/utils";
 import { motion } from "framer-motion";
 
+import { useTemplates } from "@/client/services/template";
 import { useResumeStore } from "@/client/stores/resume";
 
 import { SectionIcon } from "../shared/section-icon";
@@ -10,6 +11,7 @@ import { SectionIcon } from "../shared/section-icon";
 export const TemplateSection = () => {
   const setValue = useResumeStore((state) => state.setValue);
   const currentTemplate = useResumeStore((state) => state.resume.data.metadata.template);
+  const { templates } = useTemplates();
 
   return (
     <section id="template" className="grid gap-y-6">
@@ -21,7 +23,7 @@ export const TemplateSection = () => {
       </header>
 
       <main className="grid grid-cols-2 gap-8 @lg/right:grid-cols-3 @2xl/right:grid-cols-4">
-        {templatesList.map((template, index) => (
+        {templates?.builtIn.map((template, index) => (
           <AspectRatio key={template} ratio={1 / 1.4142}>
             <motion.div
               initial={{ opacity: 0 }}
@@ -40,6 +42,33 @@ export const TemplateSection = () => {
               <div className="absolute inset-x-0 bottom-0 h-32 w-full bg-gradient-to-b from-transparent to-background/80">
                 <p className="absolute inset-x-0 bottom-2 text-center font-bold capitalize text-primary">
                   {template}
+                </p>
+              </div>
+            </motion.div>
+          </AspectRatio>
+        ))}
+        {templates?.community.map((template, index) => (
+          <AspectRatio key={template.slug} ratio={1 / 1.4142}>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{
+                opacity: 1,
+                transition: { delay: (templates.builtIn.length + index) * 0.1 },
+              }}
+              whileTap={{ scale: 0.98, transition: { duration: 0.1 } }}
+              className={cn(
+                "relative cursor-pointer rounded-sm ring-primary transition-all hover:ring-2",
+                currentTemplate === template.slug && "ring-2",
+              )}
+              onClick={() => {
+                setValue("metadata.template", template.slug);
+              }}
+            >
+              <img src={template.preview} alt={template.name} className="rounded-sm" />
+
+              <div className="absolute inset-x-0 bottom-0 h-32 w-full bg-gradient-to-b from-transparent to-background/80">
+                <p className="absolute inset-x-0 bottom-2 text-center font-bold capitalize text-primary">
+                  {template.name}
                 </p>
               </div>
             </motion.div>

--- a/apps/client/src/pages/home/sections/features/index.tsx
+++ b/apps/client/src/pages/home/sections/features/index.tsx
@@ -25,8 +25,10 @@ import {
   TextAa,
   Translate,
 } from "@phosphor-icons/react";
-import { cn, languages, templatesList } from "@reactive-resume/utils";
+import { cn, languages } from "@reactive-resume/utils";
 import { motion } from "framer-motion";
+
+import { useTemplates } from "@/client/services/template";
 
 type Feature = {
   icon: React.ReactNode;
@@ -40,7 +42,8 @@ const featureLabel = cn(
 
 export const FeaturesSection = () => {
   const languagesCount = languages.length;
-  const templatesCount = templatesList.length;
+  const { templates } = useTemplates();
+  const templatesCount = templates ? templates.builtIn.length + templates.community.length : 0;
 
   const features: Feature[] = [
     { icon: <CurrencyDollarSimple />, title: t`Free, forever` },

--- a/apps/client/src/pages/home/sections/templates/index.tsx
+++ b/apps/client/src/pages/home/sections/templates/index.tsx
@@ -2,54 +2,81 @@ import { t } from "@lingui/macro";
 import { templatesList } from "@reactive-resume/utils";
 import { motion } from "framer-motion";
 
-export const TemplatesSection = () => (
-  <section id="sample-resumes" className="relative py-24 sm:py-32">
-    <div className="container flex flex-col gap-12 lg:min-h-[600px] lg:flex-row lg:items-start">
-      <div className="space-y-4 lg:mt-16 lg:basis-96">
-        <h2 className="text-4xl font-bold">{t`Templates`}</h2>
+import { useTemplates } from "@/client/services/template";
 
-        <p className="leading-relaxed">
-          {t`Explore the templates available in Reactive Resume and view the resumes crafted with them. They could also serve as examples to help guide the creation of your next resume.`}
-        </p>
-      </div>
+export const TemplatesSection = () => {
+  const { templates } = useTemplates();
 
-      <div className="w-full overflow-hidden lg:absolute lg:right-0 lg:max-w-[55%]">
-        <motion.div
-          animate={{
-            x: [0, templatesList.length * 200 * -1],
-            transition: {
-              x: {
-                duration: 30,
-                repeat: Number.POSITIVE_INFINITY,
-                repeatType: "mirror",
+  const community = templates?.community ?? [];
+
+  return (
+    <section id="sample-resumes" className="relative py-24 sm:py-32">
+      <div className="container flex flex-col gap-12 lg:min-h-[600px] lg:flex-row lg:items-start">
+        <div className="space-y-4 lg:mt-16 lg:basis-96">
+          <h2 className="text-4xl font-bold">{t`Templates`}</h2>
+
+          <p className="leading-relaxed">
+            {t`Explore the templates available in Reactive Resume and view the resumes crafted with them. They could also serve as examples to help guide the creation of your next resume.`}
+          </p>
+        </div>
+
+        <div className="w-full overflow-hidden lg:absolute lg:right-0 lg:max-w-[55%]">
+          <motion.div
+            animate={{
+              x: [0, (templatesList.length + community.length) * 200 * -1],
+              transition: {
+                x: {
+                  duration: 30,
+                  repeat: Number.POSITIVE_INFINITY,
+                  repeatType: "mirror",
+                },
               },
-            },
-          }}
-          className="flex items-center gap-x-6"
-        >
-          {templatesList.map((template, index) => (
-            <motion.a
-              key={index}
-              target="_blank"
-              rel="noreferrer"
-              href={`templates/pdf/${template}.pdf`}
-              className="max-w-none flex-none"
-              viewport={{ once: true }}
-              initial={{ opacity: 0, x: -100 }}
-              whileInView={{ opacity: 1, x: 0 }}
-            >
-              <img
-                alt={template}
-                loading="lazy"
-                src={`/templates/jpg/${template}.jpg`}
-                className="aspect-[1/1.4142] h-[400px] rounded object-cover lg:h-[600px]"
-              />
-            </motion.a>
-          ))}
-        </motion.div>
+            }}
+            className="flex items-center gap-x-6"
+          >
+            {templatesList.map((template, index) => (
+              <motion.a
+                key={index}
+                target="_blank"
+                rel="noreferrer"
+                href={`templates/pdf/${template}.pdf`}
+                className="max-w-none flex-none"
+                viewport={{ once: true }}
+                initial={{ opacity: 0, x: -100 }}
+                whileInView={{ opacity: 1, x: 0 }}
+              >
+                <img
+                  alt={template}
+                  loading="lazy"
+                  src={`/templates/jpg/${template}.jpg`}
+                  className="aspect-[1/1.4142] h-[400px] rounded object-cover lg:h-[600px]"
+                />
+              </motion.a>
+            ))}
+            {community.map((template, index) => (
+              <motion.a
+                key={template.slug}
+                target="_blank"
+                rel="noreferrer"
+                href={template.preview}
+                className="max-w-none flex-none"
+                viewport={{ once: true }}
+                initial={{ opacity: 0, x: -100 }}
+                whileInView={{ opacity: 1, x: 0 }}
+              >
+                <img
+                  alt={template.name}
+                  loading="lazy"
+                  src={template.preview}
+                  className="aspect-[1/1.4142] h-[400px] rounded object-cover lg:h-[600px]"
+                />
+              </motion.a>
+            ))}
+          </motion.div>
 
-        <div className="pointer-events-none absolute inset-y-0 left-0 hidden w-1/2 bg-gradient-to-r from-background to-transparent lg:block" />
+          <div className="pointer-events-none absolute inset-y-0 left-0 hidden w-1/2 bg-gradient-to-r from-background to-transparent lg:block" />
+        </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};

--- a/apps/client/src/services/template/index.ts
+++ b/apps/client/src/services/template/index.ts
@@ -1,0 +1,1 @@
+export * from "./templates";

--- a/apps/client/src/services/template/templates.ts
+++ b/apps/client/src/services/template/templates.ts
@@ -1,0 +1,24 @@
+import type { TemplateDto } from "@reactive-resume/dto";
+import { useQuery } from "@tanstack/react-query";
+
+import { TEMPLATES_KEY } from "@/client/constants/query-keys";
+import { axios } from "@/client/libs/axios";
+
+export const fetchTemplates = async () => {
+  const response = await axios.get<{ builtIn: string[]; community: TemplateDto[] }>(`/template`);
+
+  return response.data;
+};
+
+export const useTemplates = () => {
+  const {
+    error,
+    isPending: loading,
+    data,
+  } = useQuery({
+    queryKey: TEMPLATES_KEY,
+    queryFn: fetchTemplates,
+  });
+
+  return { templates: data, loading, error };
+};

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -16,6 +16,7 @@ import { MailModule } from "./mail/mail.module";
 import { PrinterModule } from "./printer/printer.module";
 import { ResumeModule } from "./resume/resume.module";
 import { StorageModule } from "./storage/storage.module";
+import { TemplateModule } from "./template/template.module";
 import { TranslationModule } from "./translation/translation.module";
 import { UserModule } from "./user/user.module";
 
@@ -37,12 +38,18 @@ import { UserModule } from "./user/user.module";
     FeatureModule,
     TranslationModule,
     ContributorsModule,
+    TemplateModule,
 
     // Static Assets
     ServeStaticModule.forRoot({
       serveRoot: "/artboard",
       // eslint-disable-next-line unicorn/prefer-module
       rootPath: path.join(__dirname, "..", "artboard"),
+    }),
+    ServeStaticModule.forRoot({
+      serveRoot: "/community-templates",
+      // eslint-disable-next-line unicorn/prefer-module
+      rootPath: path.join(__dirname, "..", "..", "..", "plugins", "templates"),
     }),
     ServeStaticModule.forRoot({
       renderPath: "/*",

--- a/apps/server/src/config/schema.ts
+++ b/apps/server/src/config/schema.ts
@@ -83,6 +83,8 @@ export const configSchema = z.object({
   OPENID_SCOPE: z.string().optional(),
   OPENID_TOKEN_URL: z.string().url().optional(),
   OPENID_USER_INFO_URL: z.string().url().optional(),
+
+  TEMPLATE_PLUGIN_DIR: z.string().default("plugins/templates"),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/apps/server/src/template/template.controller.ts
+++ b/apps/server/src/template/template.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from "@nestjs/common";
+
+import { TemplateService } from "./template.service";
+
+@Controller("template")
+export class TemplateController {
+  constructor(private readonly templateService: TemplateService) {}
+
+  @Get()
+  listTemplates() {
+    return this.templateService.getTemplates();
+  }
+}

--- a/apps/server/src/template/template.module.ts
+++ b/apps/server/src/template/template.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+
+import { TemplateController } from "./template.controller";
+import { TemplateService } from "./template.service";
+
+@Module({
+  controllers: [TemplateController],
+  providers: [TemplateService],
+})
+export class TemplateModule {}

--- a/apps/server/src/template/template.service.ts
+++ b/apps/server/src/template/template.service.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { TemplateDto } from "@reactive-resume/dto";
+import { templatesList } from "@reactive-resume/utils";
+
+import type { Config } from "../config/schema";
+
+@Injectable()
+export class TemplateService {
+  constructor(private readonly configService: ConfigService<Config>) {}
+
+  async getCommunityTemplates(): Promise<TemplateDto[]> {
+    const pluginDir = this.configService.get<string>("TEMPLATE_PLUGIN_DIR", "plugins/templates");
+    try {
+      const entries = await fs.readdir(pluginDir, { withFileTypes: true });
+      const templates = [] as TemplateDto[];
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const manifestPath = path.join(pluginDir, entry.name, "template.json");
+        try {
+          const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as TemplateDto;
+          templates.push(manifest);
+        } catch {
+          // ignore malformed plugin
+        }
+      }
+      return templates;
+    } catch {
+      return [];
+    }
+  }
+
+  async getTemplates() {
+    const community = await this.getCommunityTemplates();
+    return { builtIn: templatesList, community };
+  }
+}

--- a/libs/dto/src/index.ts
+++ b/libs/dto/src/index.ts
@@ -5,4 +5,5 @@ export * from "./feature";
 export * from "./resume";
 export * from "./secrets";
 export * from "./statistics";
+export * from "./template";
 export * from "./user";

--- a/libs/dto/src/template/index.ts
+++ b/libs/dto/src/template/index.ts
@@ -1,0 +1,1 @@
+export * from "./template";

--- a/libs/dto/src/template/template.ts
+++ b/libs/dto/src/template/template.ts
@@ -1,0 +1,12 @@
+import { createZodDto } from "nestjs-zod/dto";
+import { z } from "zod";
+
+export const templateInfoSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  author: z.string().optional(),
+  description: z.string().optional(),
+  preview: z.string().optional(),
+});
+
+export class TemplateDto extends createZodDto(templateInfoSchema) {}

--- a/plugins/templates/sample/preview.jpg
+++ b/plugins/templates/sample/preview.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/plugins/templates/sample/template.json
+++ b/plugins/templates/sample/template.json
@@ -1,0 +1,7 @@
+{
+  "slug": "sample",
+  "name": "Sample Template",
+  "author": "Community",
+  "description": "Example community template",
+  "preview": "/community-templates/sample/preview.jpg"
+}


### PR DESCRIPTION
## Summary
- update features list in README
- set up TemplateDto and marketplace plugin system
- load community templates from plugins directory
- expose templates over new `/template` API route
- list marketplace templates in the UI alongside built-ins
- document plugin directory in `.env.example`

## Testing
- `pnpm test`
- `pnpm lint:fix`